### PR TITLE
fix missing bootstrap containers to prevent x-overflow

### DIFF
--- a/CaSSAndRA/src/assets/style.css
+++ b/CaSSAndRA/src/assets/style.css
@@ -49,6 +49,12 @@
   margin-left: 10px;
 }
 
+
+/* fix width of hidden input element to prevent overflow in x direction (scrollbar) */
+#upload-sunray-file input {
+  width: 100%;
+}
+
 /* montserrat-regular - latin */
 @font-face {
   font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */

--- a/CaSSAndRA/src/pages/mapping.py
+++ b/CaSSAndRA/src/pages/mapping.py
@@ -14,7 +14,7 @@ dash.register_page(
 )
 
 def update_layout() -> html.Div:
-    return html.Div([
+    return dbc.Container([
             dbc.Row([
                 dbc.Col([
                     html.Div(className='loader-wrapper', 
@@ -62,6 +62,6 @@ def update_layout() -> html.Div:
                 modal.nofixsolution,
                 html.Div(id=ids.MAPPINGHIDDEN, style={'display': 'none'}),
                 ])
-            ])
+            ], fluid=True)
 
 layout = update_layout()

--- a/CaSSAndRA/src/pages/state.py
+++ b/CaSSAndRA/src/pages/state.py
@@ -15,7 +15,7 @@ dash.register_page(
 )
 
 def update_layout() -> html.Div:
-    return html.Div([
+    return dbc.Container([
             dbc.Row([
                 dbc.Col([
                     dbc.Row(id=ids.STATESTRING),
@@ -53,6 +53,6 @@ def update_layout() -> html.Div:
                     ])
                 ], xs=12, sm=6, lg=6)
             ]),
-    ])
+    ], fluid=True)
 
 layout = update_layout()

--- a/CaSSAndRA/src/pages/taskplanner.py
+++ b/CaSSAndRA/src/pages/taskplanner.py
@@ -15,7 +15,7 @@ dash.register_page(
 )
 
 def update_layout() -> html.Div:
-       return html.Div([
+       return dbc.Container([
                 dbc.Row([
                     dbc.Col([
                         html.Div(className='loader-wrapper', 
@@ -48,7 +48,7 @@ def update_layout() -> html.Div:
                 modaltaskmowsettings.mowsettings,     
                 modal.savecurrenttask,  
                 modal.removecurrenttask,       
-            ])
+            ], fluid=True)
             
 
 layout = update_layout()


### PR DESCRIPTION
Should fix the scrollbar issue #11 with minimal changes. 

  - The top most boostrap rows need a container (more or less every page)
  - dcc.upload had a large transparent input field