### PR TITLE
Settings styling part 2

### DIFF
--- a/CaSSAndRA/src/assets/style.css
+++ b/CaSSAndRA/src/assets/style.css
@@ -239,3 +239,6 @@ html {
   }
 }
 /************************* End of Map Controls Size Adjustment ******************/
+
+/* Boolean Switch Fix */
+.daq-booleanswitch--light__background { box-sizing: content-box; }

--- a/CaSSAndRA/src/backend/data/cfgdata.py
+++ b/CaSSAndRA/src/backend/data/cfgdata.py
@@ -211,10 +211,10 @@ class PathPlannerCfg:
     width: float = 0.18
     angle: int = 0
     distancetoborder: int = 1
-    mowarea: str() = 'yes'
+    mowarea: bool = True
     mowborder: int = 1
-    mowexclusion: str() = 'yes'
-    mowborderccw: str() = 'yes'
+    mowexclusion: bool = True
+    mowborderccw: bool = True
 
     def read_pathplannercfg(self) -> None:
         try:

--- a/CaSSAndRA/src/backend/map/cutedge.py
+++ b/CaSSAndRA/src/backend/map/cutedge.py
@@ -8,8 +8,8 @@ def check_direct_way(border: Polygon, start: list, end: list) -> bool:
     direct_way_possible = way.within(border)
     return direct_way_possible
 
-def create_route(perimeter: Polygon, mowborder: str, mowexclusion: str, 
-                 mowborderccw: str, last_coord: list, border: Polygon,
+def create_route(perimeter: Polygon, mowborder: str, mowexclusion: bool, 
+                 mowborderccw: bool, last_coord: list, border: Polygon,
                  figure: str) -> list():
     route_tmp = []
     edges_pol = []
@@ -19,7 +19,7 @@ def create_route(perimeter: Polygon, mowborder: str, mowexclusion: str,
         route_tmp = list(dict.fromkeys(route_tmp))
         ring = LinearRing(route_tmp)
         ###Check is counter clock wise###
-        if not ring.is_ccw and mowborderccw == 'yes':
+        if not ring.is_ccw and mowborderccw == True:
             route_tmp.reverse()
         ###Look for shortest way from start point###
         first_coords = [min(route_tmp, key=lambda coord: (coord[0]-last_coord[0])**2 + (coord[1]-last_coord[1])**2)]
@@ -32,7 +32,7 @@ def create_route(perimeter: Polygon, mowborder: str, mowexclusion: str,
                 logger.debug('Coverage path planner (planing route for cut to edge): No direct way for cut to edge possible, figure saved as to do for path planner')
                 edges_pol.append(Polygon(perimeter.exterior.coords))
                 route_tmp = []
-    if mowexclusion == 'yes':
+    if mowexclusion == True:
         for i in range(len(perimeter.interiors)):
             edges_pol.append(Polygon(perimeter.interiors[i].coords))
     return route_tmp, edges_pol

--- a/CaSSAndRA/src/backend/map/path.py
+++ b/CaSSAndRA/src/backend/map/path.py
@@ -77,7 +77,7 @@ def calc(selected_perimeter: Polygon, parameters: PathPlannerCfg, start_pos: lis
         selected_area_turned = map.turn(selected_perimeter, parameters.angle)
         area_to_mow, border = map.border(selected_area_turned, parameters.distancetoborder, parameters.width)
         route, edge_polygons = cutedge.calcroute(border, parameters, list(start_pos.coords))
-        if parameters.mowarea == 'yes':
+        if parameters.mowarea == True:
             line_mask = map.linemask(area_to_mow, parameters.width)
         else:
             line_mask = MultiLineString()
@@ -85,7 +85,7 @@ def calc(selected_perimeter: Polygon, parameters: PathPlannerCfg, start_pos: lis
         route = map.turn(route, -parameters.angle)
         route = list(route.coords)
 
-    if parameters.pattern == 'squares' and parameters.mowarea == 'yes':
+    if parameters.pattern == 'squares' and parameters.mowarea == True:
         last_coord = route[-1]
         last_coord = Point(last_coord)
         last_coord = map.turn(last_coord, parameters.angle+90)

--- a/CaSSAndRA/src/components/modalmowsettings.py
+++ b/CaSSAndRA/src/components/modalmowsettings.py
@@ -56,9 +56,9 @@ def toggle_modal(n_clicks_bms: int, n_clicks_bok: int,
             pathplannercfgstate.angle = mowangle
         if distancetoborder != None:
             pathplannercfgstate.distancetoborder = distancetoborder
-        pathplannercfgstate.mowarea = "yes" if mowarea == True else "no"
-        pathplannercfgstate.mowexclusion = "yes" if mowexclusion == True else "no"
-        pathplannercfgstate.mowborderccw = "yes" if mowborderccw == True else "no"
+        pathplannercfgstate.mowarea = mowarea
+        pathplannercfgstate.mowexclusion = mowexclusion
+        pathplannercfgstate.mowborderccw = mowborderccw
         pathplannercfgstate.mowborder = mowborder
             
     if n_clicks_bms or n_clicks_bok:
@@ -70,9 +70,9 @@ def toggle_modal(n_clicks_bms: int, n_clicks_bok: int,
           Output(ids.INPUTMOWCUTEDGEBORDERSTATE, 'value'),
           Output(ids.INPUTDISTANCETOBORDERSTATE, 'value'),
           Output(ids.INPUTPATTERNSTATE, 'value'),
-          Output(ids.INPUTMOWAREASTATE, 'value'),
-          Output(ids.INPUTMOWCUTEDGEEXCLUSIONSTATE, 'value'),
-          Output(ids.INPUTMOWCUTEDGEBORDERCCWSTATE, 'value'),
+          Output(ids.INPUTMOWAREASTATE, 'on'),
+          Output(ids.INPUTMOWCUTEDGEEXCLUSIONSTATE, 'on'),
+          Output(ids.INPUTMOWCUTEDGEBORDERCCWSTATE, 'on'),
           [Input(ids.URLUPDATE, 'pathname')])
 def update_pathplandersettings_on_reload(pathname: str) -> list:
     return pathplannercfgstate.width, pathplannercfgstate.angle, pathplannercfgstate.mowborder, pathplannercfgstate.distancetoborder, pathplannercfgstate.pattern, pathplannercfgstate.mowarea, pathplannercfgstate.mowexclusion, pathplannercfgstate.mowborderccw

--- a/CaSSAndRA/src/components/modalmowsettings.py
+++ b/CaSSAndRA/src/components/modalmowsettings.py
@@ -4,144 +4,27 @@ import dash_bootstrap_components as dbc
 from . import ids
 from src.backend.data.cfgdata import pathplannercfgstate
 
+from . import mowsettingstemplate as mst
+
+template = mst.get_mow_settings_template(ids.INPUTPATTERNSTATE, pathplannercfgstate.pattern,
+                                        ids.INPUTMOWOFFSETSTATE, pathplannercfgstate.width,
+                                        ids.INPUTMOWOANGLESTATE, pathplannercfgstate.angle,
+                                        ids.INPUTDISTANCETOBORDERSTATE, pathplannercfgstate.distancetoborder,
+                                        ids.INPUTMOWCUTEDGEBORDERSTATE, pathplannercfgstate.mowborder, 
+                                        ids.INPUTMOWAREASTATE, pathplannercfgstate.mowarea,
+                                        ids.INPUTMOWCUTEDGEEXCLUSIONSTATE, pathplannercfgstate.mowexclusion,
+                                        ids.INPUTMOWCUTEDGEBORDERCCWSTATE, pathplannercfgstate.mowborderccw
+                                        )
+
 mowsettings = dbc.Modal([
                 dbc.ModalHeader(dbc.ModalTitle('Mow settings')),
                 dbc.ModalBody([
-                    
-                    dbc.ListGroup(
-                    [
-                        dbc.ListGroupItem(
-                            # Line Settings
-                            dbc.Row([
-                                dbc.Col([  
-                                    html.P(['Pattern'], className='mb-0'),
-                                    dbc.Select(
-                                        id=ids.INPUTPATTERNSTATE, 
-                                        options=[
-                                            {'label': 'lines', 'value': 'lines'},
-                                            {'label': 'squares', 'value': 'squares'},
-                                            {'label': 'rings', 'value': 'rings'},
-                                        ],
-                                        value=pathplannercfgstate.pattern, style={"padding-top" : "0.17rem", "padding-bottom" : "0.17rem"}
-                                    ),
-                                ]),
-                                dbc.Col([  
-                                    html.P(['Width'], className='mb-0'),
-                                    dbc.Input(id=ids.INPUTMOWOFFSETSTATE, 
-                                            value=pathplannercfgstate.width, 
-                                            type='number', 
-                                            min=0, 
-                                            max=1, 
-                                            step=0.01, 
-                                            size='sm'
-                                    ), 
-                                ]),
-                                dbc.Col([  
-                                    html.P(['Angle'], className='mb-0'),
-                                    dbc.Input(id=ids.INPUTMOWOANGLESTATE, 
-                                            value=pathplannercfgstate.angle, 
-                                            type='number', 
-                                            min=0, 
-                                            max=359, 
-                                            step=1, 
-                                            size='sm'
-                                    ),
-                                ]),
-                            ], style={"padding-bottom" : "0.75rem"}),
-                        style={"padding-left" : "0.75rem", "padding-right" : "0.75erem", "padding-bottom" : "0.5rem", "padding-top" : "1.0rem"}),
-                        
-                        dbc.ListGroupItem(
-                            # Perimeter Settings
-                            dbc.Row([
-                                dbc.Col([  
-                                    html.P(['Distance to border'], className='mb-0'),
-                                    dbc.Input(id=ids.INPUTDISTANCETOBORDERSTATE, 
-                                            value=pathplannercfgstate.distancetoborder, 
-                                            type='number', 
-                                            min=0, 
-                                            max=5, 
-                                            step=1, 
-                                            size='sm'
-                                    ),
-                                ]),
-                                dbc.Col([  
-                                    html.P(['Border rounds'], className='mb-0'),
-                                    dbc.Input(id=ids.INPUTMOWCUTEDGEBORDERSTATE, 
-                                            value=pathplannercfgstate.mowborder, 
-                                            type='number', 
-                                            min=0, 
-                                            max=6, 
-                                            step=1, 
-                                            size='sm'
-                                    ),
-                                ]),
-                            ], style={"padding-bottom" : "0.75rem"}),
-                        style={"padding-left" : "0.75rem", "padding-right" : "0.75erem", "padding-bottom" : "0.5rem", "padding-top" : "1.0rem"} ),
-                        
-                        dbc.ListGroupItem([
-                            # 
-                            dbc.Row([
-                                dbc.Col([ 
-                                    html.P(['Mow area'], className='mb-0'),
-                                ], style={"flex-grow" : "2"}),
-                                dbc.Col([ 
-                                    dbc.Select(
-                                        id=ids.INPUTMOWAREASTATE, 
-                                        options=[
-                                            {'label': 'yes', 'value': 'yes'},
-                                            {'label': 'no', 'value': 'no'}
-                                        ],
-                                        value=pathplannercfgstate.mowarea 
-                                    ),
-                                ], style={"flex-shrink" : "2"}),
-                            ], style={"padding-bottom" : "0.75rem"}),
-                            
-                            dbc.Row([
-                                dbc.Col([ 
-                                    html.P(['Mow exclusion border'], className='mb-0'),
-                                ], style={"flex-grow" : "2"}),
-                                dbc.Col([ 
-                                    dbc.Select(
-                                        id=ids.INPUTMOWCUTEDGEEXCLUSIONSTATE, 
-                                        options=[
-                                            {'label': 'yes', 'value': 'yes'},
-                                            {'label': 'no', 'value': 'no'}
-                                        ],
-                                        value=pathplannercfgstate.mowexclusion 
-                                    ),
-                                ], style={"flex-shrink" : "2"}),
-                            ], style={"padding-bottom" : "0.75rem"}),
-
-
-                            dbc.Row([
-                                dbc.Col([ 
-                                    html.P(['Mow border CCW'], className='mb-0'),
-                                ], style={"flex-grow" : "2"}),
-                                dbc.Col([ 																		
-                                    dbc.Select(
-                                        id=ids.INPUTMOWCUTEDGEBORDERCCWSTATE, 
-                                        options=[
-                                            {'label': 'yes', 'value': 'yes'},
-                                            {'label': 'no', 'value': 'no'}
-                                        ],
-                                        value=pathplannercfgstate.mowborderccw 
-                                    ),   
-                                ], style={"flex-shrink" : "2"}),
-                            ], style={"padding-bottom" : "0.75rem"}),
-                        
-                        ],
-                        style={"padding-left" : "0.75rem", "padding-right" : "0.75erem", "padding-bottom" : "0.5rem", "padding-top" : "1.0rem"} ),
-                    ],
-                    flush=True,
-                ),
-                    
-
+                    template,                    
                 ], style={"padding-top" : 0, "padding-bottom" : 0}),
                 dbc.ModalFooter(
                     dbc.Button('OK', id=ids.BUTTONOKINPUTMAPSETTINGS, className='ms-auto', n_clicks=0)
                 ),
-        ],id=ids.MODALMOWSETTINGS, is_open=False, centered=True,
-        )
+            ],id=ids.MODALMOWSETTINGS, is_open=False, centered=True, )
 
 @callback(Output(ids.MODALMOWSETTINGS, 'is_open'),
           [Input(ids.BUTTONMOWSETTINGS, 'n_clicks'),
@@ -151,16 +34,16 @@ mowsettings = dbc.Modal([
            State(ids.INPUTMOWOFFSETSTATE, 'value'),
            State(ids.INPUTMOWOANGLESTATE, 'value'),
            State(ids.INPUTDISTANCETOBORDERSTATE, 'value'),
-           State(ids.INPUTMOWAREASTATE, 'value'),
+           State(ids.INPUTMOWAREASTATE, 'on'),
            State(ids.INPUTMOWCUTEDGEBORDERSTATE, 'value'),
-           State(ids.INPUTMOWCUTEDGEEXCLUSIONSTATE, 'value'),
-           State(ids.INPUTMOWCUTEDGEBORDERCCWSTATE, 'value')])
+           State(ids.INPUTMOWCUTEDGEEXCLUSIONSTATE, 'on'),
+           State(ids.INPUTMOWCUTEDGEBORDERCCWSTATE, 'on')])
 def toggle_modal(n_clicks_bms: int, n_clicks_bok: int,
                  modal_is_open: bool, pattern: str(),
                  mowoffset: float, mowangle: int,
-                 distancetoborder: int, mowarea: str,
-                 mowborder: str, mowexclusion: str,
-                 mowborderccw: str) -> bool:
+                 distancetoborder: int, mowarea: bool,
+                 mowborder: str, mowexclusion: bool,
+                 mowborderccw: bool) -> bool:
     context = ctx.triggered_id
     if context == ids.BUTTONOKINPUTMAPSETTINGS:
         if pattern != 'lines' and pattern != 'squares' and pattern != 'rings':
@@ -173,10 +56,10 @@ def toggle_modal(n_clicks_bms: int, n_clicks_bok: int,
             pathplannercfgstate.angle = mowangle
         if distancetoborder != None:
             pathplannercfgstate.distancetoborder = distancetoborder
-        pathplannercfgstate.mowarea = mowarea
+        pathplannercfgstate.mowarea = "yes" if mowarea == True else "no"
+        pathplannercfgstate.mowexclusion = "yes" if mowexclusion == True else "no"
+        pathplannercfgstate.mowborderccw = "yes" if mowborderccw == True else "no"
         pathplannercfgstate.mowborder = mowborder
-        pathplannercfgstate.mowexclusion = mowexclusion
-        pathplannercfgstate.mowborderccw = mowborderccw
             
     if n_clicks_bms or n_clicks_bok:
         return not modal_is_open

--- a/CaSSAndRA/src/components/modaltaskmowsettings.py
+++ b/CaSSAndRA/src/components/modaltaskmowsettings.py
@@ -4,88 +4,27 @@ import dash_bootstrap_components as dbc
 from . import ids
 from src.backend.data.cfgdata import pathplannercfgtask
 
+from . import mowsettingstemplate as mst
+
+template = mst.get_mow_settings_template(ids.INPUTPATTERNTASK, pathplannercfgtask.pattern,
+                                        ids.INPUTMOWOFFSETTASK, pathplannercfgtask.width,
+                                        ids.INPUTMOWOANGLETASK, pathplannercfgtask.angle,
+                                        ids.INPUTDISTANCETOBORDERTASK, pathplannercfgtask.distancetoborder,
+                                        ids.INPUTMOWCUTEDGEBORDERTASK, pathplannercfgtask.mowborder, 
+                                        ids.INPUTMOWAREATASK, pathplannercfgtask.mowarea,
+                                        ids.INPUTMOWCUTEDGEEXCLUSIONTASK, pathplannercfgtask.mowexclusion,
+                                        ids.INPUTMOWCUTEDGEBORDERCCWTASK, pathplannercfgtask.mowborderccw
+                                        )
+
 mowsettings = dbc.Modal([
-                        dbc.ModalHeader(dbc.ModalTitle('Mow settings')),
-                        dbc.ModalBody([
-                            html.P(['pattern'], className='mb-0'),
-                            dbc.Select(
-                                id=ids.INPUTPATTERNTASK, 
-                                options=[
-                                    {'label': 'lines', 'value': 'lines'},
-                                    {'label': 'squares', 'value': 'squares'},
-                                    {'label': 'rings', 'value': 'rings'},
-                                ],
-                                value=pathplannercfgtask.pattern
-                            ),
-                            html.P(['width'], className='mb-0'),
-                            dbc.Input(id=ids.INPUTMOWOFFSETTASK, 
-                                      value=pathplannercfgtask.width, 
-                                      type='number', 
-                                      min=0, 
-                                      max=1, 
-                                      step=0.01, 
-                                      size='sm'
-                            ), 
-                            html.P(['angle'], className='mb-0'),
-                            dbc.Input(id=ids.INPUTMOWOANGLETASK, 
-                                      value=pathplannercfgtask.angle, 
-                                      type='number', 
-                                      min=0, 
-                                      max=359, 
-                                      step=1, 
-                                      size='sm'
-                            ),
-                            html.P(['distance to border'], className='mb-0'),
-                            dbc.Input(id=ids.INPUTDISTANCETOBORDERTASK, 
-                                      value=pathplannercfgtask.distancetoborder, 
-                                      type='number', 
-                                      min=0, 
-                                      max=5, 
-                                      step=1, 
-                                      size='sm'
-                            ),
-                            html.P(['mow area'], className='mb-0'),
-                            dbc.Select(
-                                id=ids.INPUTMOWAREATASK, 
-                                options=[
-                                    {'label': 'yes', 'value': 'yes'},
-                                    {'label': 'no', 'value': 'no'}
-                                ],
-                                value=pathplannercfgtask.mowarea
-                            ),
-                            html.P(['mow cut edge border (rounds)'], className='mb-0'),
-                            dbc.Input(id=ids.INPUTMOWCUTEDGEBORDERTASK, 
-                                      value=pathplannercfgtask.mowborder, 
-                                      type='number', 
-                                      min=0, 
-                                      max=6, 
-                                      step=1, 
-                                      size='sm'
-                            ),
-                            html.P(['mow cut edge exclusion'], className='mb-0'),
-                            dbc.Select(
-                                id=ids.INPUTMOWCUTEDGEEXCLUSIONTASK, 
-                                options=[
-                                    {'label': 'yes', 'value': 'yes'},
-                                    {'label': 'no', 'value': 'no'}
-                                ],
-                                value=pathplannercfgtask.mowexclusion
-                            ),
-                            html.P(['mow cut edge border in ccw'], className='mb-0'),
-                            dbc.Select(
-                                id=ids.INPUTMOWCUTEDGEBORDERCCWTASK, 
-                                options=[
-                                    {'label': 'yes', 'value': 'yes'},
-                                    {'label': 'no', 'value': 'no'}
-                                ],
-                                value=pathplannercfgtask.mowborderccw
-                            ),
-                        ]),
-                        dbc.ModalFooter(
-                            dbc.Button('OK', id=ids.BUTTONOKINPUTMOWTASKSETTINGS, className='ms-auto', n_clicks=0)
-                        ),
-                ],id=ids.MODALMOWTASKSETTINGS, is_open=False,
-                )
+                dbc.ModalHeader(dbc.ModalTitle('Mow settings')),
+                dbc.ModalBody([
+                    template,               
+                ]),
+                dbc.ModalFooter(
+                    dbc.Button('OK', id=ids.BUTTONOKINPUTMOWTASKSETTINGS, className='ms-auto', n_clicks=0)
+                ),
+            ],id=ids.MODALMOWTASKSETTINGS, is_open=False, centered=True)
 
 @callback(Output(ids.MODALMOWTASKSETTINGS, 'is_open'),
           [Input(ids.BUTTONPLANMOWSETTINGS, 'n_clicks'),
@@ -95,16 +34,16 @@ mowsettings = dbc.Modal([
            State(ids.INPUTMOWOFFSETTASK, 'value'),
            State(ids.INPUTMOWOANGLETASK, 'value'),
            State(ids.INPUTDISTANCETOBORDERTASK, 'value'),
-           State(ids.INPUTMOWAREATASK, 'value'),
+           State(ids.INPUTMOWAREATASK, 'on'),
            State(ids.INPUTMOWCUTEDGEBORDERTASK, 'value'),
-           State(ids.INPUTMOWCUTEDGEEXCLUSIONTASK, 'value'),
-           State(ids.INPUTMOWCUTEDGEBORDERCCWTASK, 'value')])
+           State(ids.INPUTMOWCUTEDGEEXCLUSIONTASK, 'on'),
+           State(ids.INPUTMOWCUTEDGEBORDERCCWTASK, 'on')])
 def toggle_modal(n_clicks_bms: int, n_clicks_bok: int,
                  modal_is_open: bool, pattern: str(),
                  mowoffset: float, mowangle: int,
-                 distancetoborder: int, mowarea: str,
-                 mowborder: str, mowexclusion: str,
-                 mowborderccw: str) -> bool:
+                 distancetoborder: int, mowarea: bool,
+                 mowborder: str, mowexclusion: bool,
+                 mowborderccw: bool) -> bool:
     context = ctx.triggered_id
     if context == ids.BUTTONOKINPUTMOWTASKSETTINGS:
         if pattern != 'lines' and pattern != 'squares' and pattern != 'rings':
@@ -117,10 +56,10 @@ def toggle_modal(n_clicks_bms: int, n_clicks_bok: int,
             pathplannercfgtask.angle = mowangle
         if distancetoborder != None:
             pathplannercfgtask.distancetoborder = distancetoborder
-        pathplannercfgtask.mowarea = mowarea
+        pathplannercfgtask.mowarea = "yes" if mowarea == True else "no"
+        pathplannercfgtask.mowexclusion = "yes" if mowexclusion == True else "no"
+        pathplannercfgtask.mowborderccw = "yes" if mowborderccw == True else "no"
         pathplannercfgtask.mowborder = mowborder
-        pathplannercfgtask.mowexclusion = mowexclusion
-        pathplannercfgtask.mowborderccw = mowborderccw
             
     if n_clicks_bms or n_clicks_bok:
         return not modal_is_open

--- a/CaSSAndRA/src/components/modaltaskmowsettings.py
+++ b/CaSSAndRA/src/components/modaltaskmowsettings.py
@@ -20,7 +20,7 @@ mowsettings = dbc.Modal([
                 dbc.ModalHeader(dbc.ModalTitle('Mow settings')),
                 dbc.ModalBody([
                     template,               
-                ]),
+                ], style={"padding-top" : 0, "padding-bottom" : 0}),
                 dbc.ModalFooter(
                     dbc.Button('OK', id=ids.BUTTONOKINPUTMOWTASKSETTINGS, className='ms-auto', n_clicks=0)
                 ),

--- a/CaSSAndRA/src/components/modaltaskmowsettings.py
+++ b/CaSSAndRA/src/components/modaltaskmowsettings.py
@@ -56,9 +56,9 @@ def toggle_modal(n_clicks_bms: int, n_clicks_bok: int,
             pathplannercfgtask.angle = mowangle
         if distancetoborder != None:
             pathplannercfgtask.distancetoborder = distancetoborder
-        pathplannercfgtask.mowarea = "yes" if mowarea == True else "no"
-        pathplannercfgtask.mowexclusion = "yes" if mowexclusion == True else "no"
-        pathplannercfgtask.mowborderccw = "yes" if mowborderccw == True else "no"
+        pathplannercfgtask.mowarea = mowarea
+        pathplannercfgtask.mowexclusion = mowexclusion
+        pathplannercfgtask.mowborderccw = mowborderccw
         pathplannercfgtask.mowborder = mowborder
             
     if n_clicks_bms or n_clicks_bok:
@@ -70,9 +70,9 @@ def toggle_modal(n_clicks_bms: int, n_clicks_bok: int,
           Output(ids.INPUTMOWCUTEDGEBORDERTASK, 'value'),
           Output(ids.INPUTDISTANCETOBORDERTASK, 'value'),
           Output(ids.INPUTPATTERNTASK, 'value'),
-          Output(ids.INPUTMOWAREATASK, 'value'),
-          Output(ids.INPUTMOWCUTEDGEEXCLUSIONTASK, 'value'),
-          Output(ids.INPUTMOWCUTEDGEBORDERCCWTASK, 'value'),
+          Output(ids.INPUTMOWAREATASK, 'on'),
+          Output(ids.INPUTMOWCUTEDGEEXCLUSIONTASK, 'on'),
+          Output(ids.INPUTMOWCUTEDGEBORDERCCWTASK, 'on'),
           [Input(ids.URLUPDATE, 'pathname')])
 def update_pathplandersettings_on_reload(pathname: str) -> list:
     return pathplannercfgtask.width, pathplannercfgtask.angle, pathplannercfgtask.mowborder, pathplannercfgtask.distancetoborder, pathplannercfgtask.pattern, pathplannercfgtask.mowarea, pathplannercfgtask.mowexclusion, pathplannercfgtask.mowborderccw

--- a/CaSSAndRA/src/components/mowsettingstemplate.py
+++ b/CaSSAndRA/src/components/mowsettingstemplate.py
@@ -1,0 +1,128 @@
+from dash import html, Input, Output, State, callback, ctx
+import dash_bootstrap_components as dbc
+import dash_daq as daq
+
+def get_mow_settings_template(idInputPattern, cfgPattern,
+                              idInputMowOffset, cfgWidth,
+                              idMowAngle, cfgAngle,
+                              idDistanceBorder, cfgDistanceBorder,
+                              idMowBorder, cfgMowBorder,
+                              idMowArea, cfgMowArea,
+                              idMowExclusion, cfgMowExclusion,
+                              idMowBorderCCW, cfgMowBorderCCW):
+    return dbc.ListGroup([
+            dbc.ListGroupItem(
+                # Line Settings
+                dbc.Row([
+                    dbc.Col([  
+                        html.P(['Pattern'], className='mb-0'),
+                        dbc.Select(
+                            id=idInputPattern, 
+                            options=[
+                                {'label': 'lines', 'value': 'lines'},
+                                {'label': 'squares', 'value': 'squares'},
+                                {'label': 'rings', 'value': 'rings'},
+                            ],
+                            value=cfgPattern, style={"padding-top" : "0.17rem", "padding-bottom" : "0.17rem"}
+                        ),
+                    ]),
+                    dbc.Col([  
+                        html.P(['Width'], className='mb-0'),
+                        dbc.Input(id=idInputMowOffset, 
+                                value=cfgWidth,
+                                type='number', 
+                                min=0, 
+                                max=1, 
+                                step=0.01, 
+                                size='sm'
+                        ), 
+                    ]),
+                    dbc.Col([  
+                        html.P(['Angle'], className='mb-0'),
+                        dbc.Input(id=idMowAngle, 
+                                value=cfgAngle, 
+                                type='number', 
+                                min=0, 
+                                max=359, 
+                                step=1, 
+                                size='sm'
+                        ),
+                    ]),
+                ], style={"padding-bottom" : "0.75rem"}),
+            style={"padding-left" : "0.75rem", "padding-right" : "0.75erem", "padding-bottom" : "0.5rem", "padding-top" : "1.0rem"}),
+            
+            dbc.ListGroupItem(
+                # Perimeter Settings
+                dbc.Row([
+                    dbc.Col([  
+                        html.P(['Distance to border'], className='mb-0'),
+                        dbc.Input(id=idDistanceBorder, 
+                                value=cfgDistanceBorder, 
+                                type='number', 
+                                min=0, 
+                                max=5, 
+                                step=1, 
+                                size='sm'
+                        ),
+                    ]),
+                    dbc.Col([  
+                        html.P(['Border rounds'], className='mb-0'),
+                        dbc.Input(id=idMowBorder, 
+                                value=cfgMowBorder, 
+                                type='number', 
+                                min=0, 
+                                max=6, 
+                                step=1, 
+                                size='sm'
+                        ),
+                    ]),
+                ], style={"padding-bottom" : "0.75rem"}),
+            style={"padding-left" : "0.75rem", "padding-right" : "0.75erem", "padding-bottom" : "0.5rem", "padding-top" : "1.0rem"} ),
+            
+            dbc.ListGroupItem([
+                # 
+                dbc.Row([
+                    dbc.Col([ 
+                        html.P(['Mow area'], className='mb-0'),
+                    ], style={"flex-grow" : "2"}),
+                    dbc.Col([ 
+                        daq.BooleanSwitch(
+                            id=idMowArea,
+                            on= True if cfgMowArea == "yes" else False,
+                            style={"float" : "right"},
+                        ),
+                    ], style={"flex-shrink" : "2"}),
+                ], style={"padding-bottom" : "0.75rem"}),
+                
+                dbc.Row([
+                    dbc.Col([ 
+                        html.P(['Mow exclusion border'], className='mb-0'),
+                    ], style={"flex-grow" : "2"}),
+                    dbc.Col([ 
+                        daq.BooleanSwitch(
+                            id=idMowExclusion,
+                            on= True if cfgMowExclusion == "yes" else False,
+                            style={"float" : "right"},
+                        ),
+                    ], style={"flex-shrink" : "2"}),
+                ], style={"padding-bottom" : "0.75rem"}),
+
+
+                dbc.Row([
+                    dbc.Col([ 
+                        html.P(['Mow border CCW'], className='mb-0'),
+                    ], style={"flex-grow" : "2"}),
+                    dbc.Col([ 			
+                        daq.BooleanSwitch(
+                            id=idMowBorderCCW,
+                            on= True if cfgMowBorderCCW == "yes" else False,
+                            style={"float" : "right"},
+                        ),															 
+                    ], style={"flex-shrink" : "2"}),
+                ], style={"padding-bottom" : "0.75rem"}),
+            
+            ],
+            style={"padding-left" : "0.75rem", "padding-right" : "0.75erem", "padding-bottom" : "0.5rem", "padding-top" : "1.0rem"} ),
+        ],
+        flush=True,
+    )

--- a/CaSSAndRA/src/components/mowsettingstemplate.py
+++ b/CaSSAndRA/src/components/mowsettingstemplate.py
@@ -88,8 +88,9 @@ def get_mow_settings_template(idInputPattern, cfgPattern,
                     dbc.Col([ 
                         daq.BooleanSwitch(
                             id=idMowArea,
-                            on= True if cfgMowArea == "yes" else False,
+                            on= cfgMowArea,
                             style={"float" : "right"},
+                            color="#afe0d2",
                         ),
                     ], style={"flex-shrink" : "2"}),
                 ], style={"padding-bottom" : "0.75rem"}),
@@ -101,12 +102,12 @@ def get_mow_settings_template(idInputPattern, cfgPattern,
                     dbc.Col([ 
                         daq.BooleanSwitch(
                             id=idMowExclusion,
-                            on= True if cfgMowExclusion == "yes" else False,
+                            on= cfgMowExclusion,
                             style={"float" : "right"},
+                            color="#afe0d2",
                         ),
                     ], style={"flex-shrink" : "2"}),
                 ], style={"padding-bottom" : "0.75rem"}),
-
 
                 dbc.Row([
                     dbc.Col([ 
@@ -115,8 +116,9 @@ def get_mow_settings_template(idInputPattern, cfgPattern,
                     dbc.Col([ 			
                         daq.BooleanSwitch(
                             id=idMowBorderCCW,
-                            on= True if cfgMowBorderCCW == "yes" else False,
+                            on= cfgMowBorderCCW,
                             style={"float" : "right"},
+                            color="#afe0d2",
                         ),															 
                     ], style={"flex-shrink" : "2"}),
                 ], style={"padding-bottom" : "0.75rem"}),

--- a/CaSSAndRA/src/components/settings/accordion.py
+++ b/CaSSAndRA/src/components/settings/accordion.py
@@ -1,5 +1,6 @@
 from dash import html, Input, Output, State, callback, ctx
 import dash_bootstrap_components as dbc
+import dash_daq as daq
 import time
 
 from .. import ids
@@ -78,34 +79,34 @@ accordion_settings = dbc.Accordion([
                                 dbc.Input(value=pathplannercfg.angle, id=ids.MOWANGLESETTINGS, type='number', min=0, max=359, step=1),
                                 dbc.FormText('Distance to border'),
                                 dbc.Input(value=pathplannercfg.distancetoborder, id=ids.DISTANCETOBORDERSETTINGS, type='number', min=0, max=5, step=1),
-                                dbc.FormText('Mow area'),
-                                dbc.Select(
-                                    id=ids.MOWAREASETTINGS,
-                                    options=[
-                                        {'label': 'yes', 'value': 'yes'},
-                                        {'label': 'no', 'value': 'no'},
-                                    ],
-                                    value=pathplannercfg.mowarea
-                                ),
                                 dbc.FormText('Mow cut edge border (rounds)'),
                                 dbc.Input(value=pathplannercfg.mowborder, id=ids.MOWEDGESETTINGS, type='number', min=0, max=6, step=1),
+                                dbc.FormText('Mow area'),
+                                html.Div(
+                                    daq.BooleanSwitch(
+                                        id=ids.MOWAREASETTINGS,
+                                        on= pathplannercfg.mowarea,
+                                        style={"float" : "left"},
+                                        color="#afe0d2",
+                                    ),
+                                ),
                                 dbc.FormText('Mow cut edge exclusion'),
-                                dbc.Select(
-                                    id=ids.MOWEDGEEXCLUSIONSETTINGS,
-                                    options=[
-                                        {'label': 'yes', 'value': 'yes'},
-                                        {'label': 'no', 'value': 'no'},
-                                    ],
-                                    value=pathplannercfg.mowexclusion
+                                html.Div(
+                                    daq.BooleanSwitch(
+                                        id=ids.MOWEDGEEXCLUSIONSETTINGS,
+                                        on= pathplannercfg.mowexclusion,
+                                        style={"float" : "left"},
+                                        color="#afe0d2",
+                                    ),
                                 ),
                                 dbc.FormText('Mow cut edge border in ccw'),
-                                dbc.Select(
-                                    id=ids.MOWBORDERCCWSETTINGS,
-                                    options=[
-                                        {'label': 'yes', 'value': 'yes'},
-                                        {'label': 'no', 'value': 'no'},
-                                    ],
-                                    value=pathplannercfg.mowborderccw
+                                html.Div(
+                                    daq.BooleanSwitch(
+                                        id=ids.MOWBORDERCCWSETTINGS,
+                                        on= pathplannercfg.mowborderccw,
+                                        style={"float" : "left"},
+                                        color="#afe0d2",
+                                    ),
                                 ),
                             ],
                             title='Coverage path planner',
@@ -259,15 +260,15 @@ def update_connectioninput(radio_input: str()) -> list(dict()):
            State(ids.MOWEDGESETTINGS, 'value'),
            State(ids.DISTANCETOBORDERSETTINGS, 'value'),
            State(ids.PATTERNSETTINGS, 'value'),
-           State(ids.MOWAREASETTINGS, 'value'),
-           State(ids.MOWEDGEEXCLUSIONSETTINGS, 'value'),
-           State(ids.MOWBORDERCCWSETTINGS, 'value')])
+           State(ids.MOWAREASETTINGS, 'on'),
+           State(ids.MOWEDGEEXCLUSIONSETTINGS, 'on'),
+           State(ids.MOWBORDERCCWSETTINGS, 'on')])
 def update_pathplanner_settings_data(bsr_n_clicks: int, bok_n_clicks: int, 
                                      is_open: bool, mowoffset: float, 
                                      mowangle: int, mowedge: str, 
                                      distancetoborder: int, pattern: str,
-                                     mowarea: str, mowexclusion: str,
-                                     mowborderccw: str) -> bool:
+                                     mowarea: bool, mowexclusion: bool,
+                                     mowborderccw: bool) -> bool:
     context = ctx.triggered_id
     if context == ids.BUTTONOKMAPSETTINGS:
         pathplannercfg.pattern = pattern
@@ -365,9 +366,9 @@ def update_robotsettings_on_reload(pathname: str) -> list:
           Output(ids.MOWEDGESETTINGS, 'value'),
           Output(ids.DISTANCETOBORDERSETTINGS, 'value'),
           Output(ids.PATTERNSETTINGS, 'value'),
-          Output(ids.MOWAREASETTINGS, 'value'),
-          Output(ids.MOWEDGEEXCLUSIONSETTINGS, 'value'),
-          Output(ids.MOWBORDERCCWSETTINGS, 'value'),
+          Output(ids.MOWAREASETTINGS, 'on'),
+          Output(ids.MOWEDGEEXCLUSIONSETTINGS, 'on'),
+          Output(ids.MOWBORDERCCWSETTINGS, 'on'),
           [Input(ids.URLUPDATE, 'pathname')])
 def update_pathplandersettings_on_reload(pathname: str) -> list:
     return pathplannercfg.width, pathplannercfg.angle, pathplannercfg.mowborder, pathplannercfg.distancetoborder, pathplannercfg.pattern, pathplannercfg.mowarea, pathplannercfg.mowexclusion, pathplannercfg.mowborderccw

--- a/CaSSAndRA/src/data/user/pathplannercfg.json
+++ b/CaSSAndRA/src/data/user/pathplannercfg.json
@@ -3,8 +3,8 @@
     "width": 0.18,
     "angle": 0,
     "distancetoborder": 2,
-    "mowarea": "yes",
+    "mowarea": true,
     "mowborder": 0,
-    "mowexclusion": "yes",
-    "mowborderccw": "yes"
+    "mowexclusion": true,
+    "mowborderccw": true
 }


### PR DESCRIPTION
Adds a generic function to generate the settings components to reutilize code for both state and tasks.

Might not want to merge this right now, I added BooleanSwitches instead of the select dropdowns for the binary settings, but I cant get their visual values to update upon page reload, any ideas? They do correctly update when Cassandra is fired up for the first time...

![Aa](https://github.com/EinEinfach/CaSSAndRA/assets/36823667/858da261-9ef5-45ab-9de7-632df71f54c3)
