### PR TITLE
Maximize map available space

### DIFF
--- a/CaSSAndRA/src/components/mapping/map.py
+++ b/CaSSAndRA/src/components/mapping/map.py
@@ -35,7 +35,7 @@ mappingmap.update_layout(
                annotations=[],
      )
 mappingmap.update_xaxes(nticks=50, ticklabelstep=5)
-mappingmap.update_yaxes(nticks=50, ticklabelstep=5)
+mappingmap.update_yaxes(nticks=50, ticklabelstep=5, ticklabelposition="inside")
 
 @callback(Output(ids.MAPPINGMAP, 'figure'),
           #Output(ids.MAPPINGINTERVAL, 'disabled', allow_duplicate=True),

--- a/CaSSAndRA/src/components/state/map.py
+++ b/CaSSAndRA/src/components/state/map.py
@@ -266,7 +266,8 @@ def update(n_intervals: int,
      fig_state['data'] = traces
      fig = go.Figure(fig_state)
      fig.update_layout(
-                    yaxis = dict(range=range_y),
+                    yaxis = dict(range=range_y, showticklabels=False),
+                    xaxis = dict(showticklabels=False),
                     images=imgs,
                     annotations=mowdata,
                     )

--- a/CaSSAndRA/src/components/tasks/map.py
+++ b/CaSSAndRA/src/components/tasks/map.py
@@ -124,8 +124,9 @@ def update(bpma_nclicks: int, bcs_nclicks: int, bpc_nclicks: int, save_is_open: 
 
     fig = {'data': traces, 
            'layout': go.Layout(
-                        yaxis=dict(range=range_y, scaleratio=1, scaleanchor='x'),
-                        margin=dict(b=20, l=20, r=20, t=30),
+                        yaxis=dict(range=range_y, scaleratio=1, scaleanchor='x', showticklabels=False),
+                    	xaxis = dict(showticklabels=False),
+                        margin=dict(b=0, l=0, r=0, t=30),
                         showlegend=False,
                         uirevision=1,
                         hovermode='closest',

--- a/CaSSAndRA/src/pages/mapping.py
+++ b/CaSSAndRA/src/pages/mapping.py
@@ -23,7 +23,7 @@ def update_layout() -> html.Div:
     main_col = dbc.Col(
         [
             html.Div(
-                className='loader-wrapper flex-grow-1 p-2',
+                className='loader-wrapper flex-grow-1',
                 children=[
                     dbc.Spinner(
                         delay_show=1000,

--- a/CaSSAndRA/src/pages/state.py
+++ b/CaSSAndRA/src/pages/state.py
@@ -38,7 +38,7 @@ def update_layout() -> html.Div:
                                     config={'displaylogo': False, 'scrollZoom': True},
                                 )
                             ],
-                            className="map-graph p-2",
+                            className="map-graph",
                         ),
                     )
                 ],

--- a/CaSSAndRA/src/pages/taskplanner.py
+++ b/CaSSAndRA/src/pages/taskplanner.py
@@ -17,7 +17,7 @@ def update_layout() -> html.Div:
         [
             # map
             html.Div(
-                className='loader-wrapper flex-grow-1 p-2',
+                className='loader-wrapper flex-grow-1',
                 children=[
                     dbc.Spinner(
                         delay_show=1000,


### PR DESCRIPTION
Removes ticks and padding to make the map plots have as much space as possible.

Ticks are kept in mapping, I couldnt get both the x and y ticks to be inside at the same time without things breaking so ticks on the x axis stay outside.