### PR TITLE
Improve docker support

### DIFF
--- a/CaSSAndRA/app.py
+++ b/CaSSAndRA/app.py
@@ -62,7 +62,7 @@ def serve_layout() -> html.Div:
 
 def main() -> None:
     backendserver.start()
-    assets_path = os.path.dirname(__file__) +'/src/assets'
+    assets_path = os.path.abspath(os.path.dirname(__file__)) +'/src/assets'
 
     app = dash.Dash(
         __name__,

--- a/CaSSAndRA/app.py
+++ b/CaSSAndRA/app.py
@@ -47,14 +47,14 @@ def cli():
 @cli.command()
 @click.option('-h', '--host', default='0.0.0.0', show_default=True)
 @click.option('-p', '--port', default=8050, show_default=True)
-@click.option('--data_path', default=default_data_path, show_default=True)
 @click.option('--proxy', default=None, help='format={{input}}::{{output}} example=http://0.0.0.0:8050::https://my.domain.com')
+@click.option('--data_path', default=default_data_path, show_default=True)
 @click.option('--debug', default=False, is_flag=True, help="Enables debug mode for dash application")
 @click.option('--app_log_level', default="DEBUG", envvar='APPLOGLEVEL', type=logging_choices, show_default=True)
 @click.option('--app_log_file_level', default="DEBUG", envvar='APPLOGFILELEVEL', type=logging_choices, show_default=True)
 @click.option('--server_log_level', default="ERROR", envvar='SERVERLOGLEVEL', type=logging_choices, show_default=True)
 @click.option('--pil_log_level', default="WARN", envvar='PILLOGLEVEL', type=logging_choices, show_default=True)
-def start(host, port, proxy, debug, app_log_level, app_log_file_level, server_log_level, pil_log_level) -> None:
+def start(host, port, proxy, data_path, debug, app_log_level, app_log_file_level, server_log_level, pil_log_level) -> None:
     """ Start the CaSSAndRA Server
 
         Only some Dash server options are handled as command-line options.
@@ -70,7 +70,7 @@ def start(host, port, proxy, debug, app_log_level, app_log_file_level, server_lo
     from src.layout import serve_layout
     from src.backend import backendserver
     
-    backendserver.start()
+    backendserver.start(data_path)
     assets_path = os.path.abspath(os.path.dirname(__file__)) +'/src/assets'
 
     app = dash.Dash(

--- a/CaSSAndRA/app.py
+++ b/CaSSAndRA/app.py
@@ -37,6 +37,8 @@ def config_logging(basic_level, log_file_level, web_server_level, pil_level):
     pil_logger.setLevel(pil_level)
 
 
+default_data_path = os.path.join(os.path.expanduser('~'), '.cassandra')
+
 
 @click.group()
 def cli():
@@ -45,6 +47,7 @@ def cli():
 @cli.command()
 @click.option('-h', '--host', default='0.0.0.0', show_default=True)
 @click.option('-p', '--port', default=8050, show_default=True)
+@click.option('--data_path', default=default_data_path, show_default=True)
 @click.option('--proxy', default=None, help='format={{input}}::{{output}} example=http://0.0.0.0:8050::https://my.domain.com')
 @click.option('--debug', default=False, is_flag=True, help="Enables debug mode for dash application")
 @click.option('--app_log_level', default="DEBUG", envvar='APPLOGLEVEL', type=logging_choices, show_default=True)

--- a/CaSSAndRA/app.py
+++ b/CaSSAndRA/app.py
@@ -51,7 +51,7 @@ def cli():
 @click.option('--data_path', default=default_data_path, show_default=True)
 @click.option('--debug', default=False, is_flag=True, help="Enables debug mode for dash application")
 @click.option('--app_log_level', default="DEBUG", envvar='APPLOGLEVEL', type=logging_choices, show_default=True)
-@click.option('--app_log_file_level', default="DEBUG", envvar='APPLOGFILELEVEL', type=logging_choices, show_default=True)
+@click.option('--app_log_file_level', default="INFO", envvar='APPLOGFILELEVEL', type=logging_choices, show_default=True)
 @click.option('--server_log_level', default="ERROR", envvar='SERVERLOGLEVEL', type=logging_choices, show_default=True)
 @click.option('--pil_log_level', default="WARN", envvar='PILLOGLEVEL', type=logging_choices, show_default=True)
 def start(host, port, proxy, data_path, debug, app_log_level, app_log_file_level, server_log_level, pil_log_level) -> None:

--- a/CaSSAndRA/app.py
+++ b/CaSSAndRA/app.py
@@ -3,64 +3,70 @@
 #Version:0.70.3 Issue no log file
 
 # package imports
+import os
 import sys
+import click
+
 import logging
 from logging.handlers import RotatingFileHandler
-import os
-import dash
-from dash import html, dcc
-import dash_bootstrap_components as dbc
 
-# local imports
-from src.components import ids, navbar, offcanvas, modalremotecontrol, modalinfo, modalerror
-from src.backend import backendserver
-
-# create logger
+# logging setup
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-rfh = RotatingFileHandler(
-            filename=os.path.dirname(__file__) +'/src/data/log/cassandra.log',
-            mode='a',
-            maxBytes=5*1024*1024,
-            backupCount=2,
-            encoding=None,
-            delay=0,
-        )   
-rfh.setLevel(logging.INFO)
-logging.basicConfig(
-            handlers=[logging.StreamHandler(sys.stdout),
-                      #logging.FileHandler('CaSSAndRA/src/data/log/cassandra.log')
-                      rfh
-                      ],
-            level=logging.DEBUG,
-            #filename='CaSSAndRA/src/data/log/cassandra.log',
-            format='%(asctime)s %(levelname)s %(message)s',
-            datefmt='%Y-%m-%d %H:%M:%S;',
-        )
+frontend_logger = logging.getLogger("werkzeug")
+pil_logger = logging.getLogger("PIL")
+logging_choices = click.Choice(["DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"])
 
-frontend_logger = logging.getLogger('werkzeug')
-frontend_logger.setLevel(logging.ERROR)
 
-pil_logger = logging.getLogger('PIL')
-pil_logger.setLevel(logging.WARNING)
+def config_logging(basic_level, log_file_level, web_server_level, pil_level):
+    rfh = RotatingFileHandler(
+        filename=os.path.dirname(__file__) + "/src/data/log/cassandra.log",
+        mode="a",
+        maxBytes=5 * 1024 * 1024,
+        backupCount=2,
+        encoding=None,
+        delay=0,
+    )
+    rfh.setLevel(log_file_level)
+    logging.basicConfig(
+        handlers=[logging.StreamHandler(sys.stdout), rfh],
+        level=basic_level,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S;",
+    )
+    frontend_logger.setLevel(web_server_level)
+    pil_logger.setLevel(pil_level)
 
-def serve_layout() -> html.Div:
-    return html.Div(
-        [
-            dcc.Interval(id=ids.INTERVAL, interval=1*3000, n_intervals=0),
-            dcc.Interval(id=ids.STATEMAPINTERVAL, interval=1*1000, n_intervals=0, disabled=False),
-            dcc.Interval(id=ids.MAPPINGINTERVAL, interval=1*3000, n_intervals=0, disabled=True),
-            dcc.Location(id=ids.URLUPDATE, refresh=True),
-            navbar.navbar,
-            offcanvas.offcanvas,
-            modalremotecontrol.confirm,
-            modalinfo.info,
-            modalerror.mapuploadfailed,
-            dash.page_container
-            #footer
-        ]) 
 
-def main() -> None:
+
+@click.group()
+def cli():
+    """CaSSAndRA App Commands"""
+
+@cli.command()
+@click.option('-h', '--host', default='0.0.0.0', show_default=True)
+@click.option('-p', '--port', default=8050, show_default=True)
+@click.option('--proxy', default=None, help='format={{input}}::{{output}} example=http://0.0.0.0:8050::https://my.domain.com')
+@click.option('--debug', default=False, is_flag=True, help="Enables debug mode for dash application")
+@click.option('--app_log_level', default="DEBUG", envvar='APPLOGLEVEL', type=logging_choices, show_default=True)
+@click.option('--app_log_file_level', default="DEBUG", envvar='APPLOGFILELEVEL', type=logging_choices, show_default=True)
+@click.option('--server_log_level', default="ERROR", envvar='SERVERLOGLEVEL', type=logging_choices, show_default=True)
+@click.option('--pil_log_level', default="WARN", envvar='PILLOGLEVEL', type=logging_choices, show_default=True)
+def start(host, port, proxy, debug, app_log_level, app_log_file_level, server_log_level, pil_log_level) -> None:
+    """ Start the CaSSAndRA Server
+
+        Only some Dash server options are handled as command-line options.
+        All other options should use environment variables.
+        Find supported environment variables here: https://dash.plotly.com/reference#app.run
+        
+    """
+    # logging config
+    config_logging(app_log_level, app_log_file_level, server_log_level, pil_log_level)
+
+    # server and app imports
+    import dash
+    from src.layout import serve_layout
+    from src.backend import backendserver
+    
     backendserver.start()
     assets_path = os.path.abspath(os.path.dirname(__file__)) +'/src/assets'
 
@@ -93,10 +99,8 @@ def main() -> None:
     )
     app.layout = serve_layout   # set the layout to the serve_layout function
 
-    #app.run_server(host='127.0.0.1', port=8050, debug=True, dev_tools_props_check=True)
-    app.run_server('0.0.0.0', debug=False, port=8050)
+    app.run_server(host=host, port=port, proxy=proxy, debug=debug)
+
 
 if __name__ == "__main__":
-    main()
-
-
+    cli()

--- a/CaSSAndRA/src/backend/backendserver.py
+++ b/CaSSAndRA/src/backend/backendserver.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import time
 import os
 
-from . data import saveddata, calceddata, cleandata
+from . data import saveddata, calceddata, cleandata, utils
 from . comm import mqttcomm, httpcomm, uartcomm, cfg
 
 restart = Event()
@@ -142,10 +142,12 @@ def connect_uart(ser, connect_data: dict(), connection: bool,restart: Event, abs
         data_clean_finished = cleandata.check(data_clean_finished)
         time.sleep(0.1)
 
-def start() -> None:
+def start(data_path) -> None:
     logger.info('Backend: Starting backend server')
-    absolute_path = os.path.dirname(__file__) 
-    logger.debug('absolute_path: '+absolute_path)
+    logger.debug(f'Backend: Using {data_path} for config and data storage')
+
+    file_paths = utils.init_data(data_path)
+    
     logger.info('Backend: Read communication config file')
     connect_data = cfg.read_commcfg(absolute_path)
     #logger.info('Backend: Read map config file')

--- a/CaSSAndRA/src/backend/backendserver.py
+++ b/CaSSAndRA/src/backend/backendserver.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import time
 import os
 
-from . data import saveddata, calceddata, cleandata, utils, cfgdata
+from . data import saveddata, calceddata, cleandata, cfgdata, logdata
 from . comm import mqttcomm, httpcomm, uartcomm, cfg
 
 restart = Event()
@@ -142,13 +142,15 @@ def connect_uart(ser, connect_data: dict(), connection: bool,restart: Event, fil
         data_clean_finished = cleandata.check(data_clean_finished)
         time.sleep(0.1)
 
-def start(data_path) -> None:
+def start(file_paths) -> None:
     logger.info('Backend: Starting backend server')
-    logger.debug(f'Backend: Using {data_path} for config and data storage')
-
-    file_paths = utils.init_data(data_path)
+    logger.debug(f'Backend: Using {file_paths.data} for config and data storage')
 
     logger.info('Backend: Read communication config file')
+    
+    # todo: this should be refactored so the class is initialized with correct data immediately
+    logdata.commlog.path = file_paths.log
+    
     # todo: this should be a class or refactored in some way to avoid having to initilize this way
     cfg.file_paths = file_paths
     connect_data = cfg.read_commcfg(file_paths.user.comm)

--- a/CaSSAndRA/src/backend/comm/cfg.py
+++ b/CaSSAndRA/src/backend/comm/cfg.py
@@ -6,15 +6,13 @@ import os
 from ..data import mapdata, appdata
 from src.backend.data.mapdata import current_map, mapping_maps
 
-def read_commcfg(absolute_path) -> dict():
+file_paths = None
+
+def read_commcfg(path_to_cfg_data) -> dict():
     logger.debug('Opening commcfg.json')
     try:
-        with open(absolute_path.replace('/src/backend', '/src/data/datacfg.json')) as f:
-            path_to_data = json.load(f)
-            f.close()
-        path_to_cfg_data = path_to_data['path'][0]['user'][0]['comm']
         logger.debug('Path to commcfg.json: '+path_to_cfg_data)
-        with open(absolute_path.replace('src/backend', path_to_cfg_data)) as f:
+        with open(path_to_cfg_data) as f:
             connect_data = json.load(f)
             logger.debug('commcfg.json content: '+str(connect_data))
             appdata.commcfg = connect_data
@@ -64,12 +62,9 @@ def read_commcfg(absolute_path) -> dict():
 def read_mapcfg(absolute_path):
     logger.debug('Opening mapcfg.json')
     try:
-        with open(absolute_path.replace('/src/backend', '/src/data/datacfg.json')) as f: 
-            path_to_data = json.load(f)
-            f.close()
-        path_to_cfg_data = path_to_data['path'][0]['user'][1]['mapcfg']
+        path_to_cfg_data = file_paths.user.mapcfg
         logger.debug('Path to mapcfg.json: '+path_to_cfg_data)
-        with open(absolute_path.replace('/src/backend', path_to_cfg_data)) as f:
+        with open(path_to_cfg_data) as f:
             mapcfg = json.load(f)
             logger.debug('mapcfg.json content: '+str(mapcfg))
             mapdata.mowoffset = mapcfg['MOWOFFSET']
@@ -106,12 +101,9 @@ def read_mapcfg(absolute_path):
 def read_appcfg(absolute_path):
     logger.debug('Opening appcfg.json')
     try:
-        with open(absolute_path.replace('/src/backend', '/src/data/datacfg.json')) as f: 
-            path_to_data = json.load(f)
-            f.close()
-        path_to_cfg_data = path_to_data['path'][0]['user'][2]['appcfg']
+        path_to_cfg_data = file_paths.user.appcfg
         logger.debug('Path to appcfg.json: '+path_to_cfg_data)
-        with open(absolute_path.replace('/src/backend', path_to_cfg_data)) as f:
+        with open(path_to_cfg_data) as f:
             appcfg = json.load(f)
             logger.debug('appcfg.json content: '+str(appcfg))
             appdata.datamaxage = appcfg['datamaxage']
@@ -132,14 +124,10 @@ def read_appcfg(absolute_path):
 
 def save_commcfg(changed_data: dict()) -> None:
     logger.info('Backend: Writing new connection data to the file')
-    absolute_path = os.path.dirname(__file__) 
     try:
-        with open(absolute_path.replace('/src/backend/comm', '/src/data/datacfg.json')) as f:
-            path_to_data = json.load(f)
-            f.close()
-        path_to_cfg_data = path_to_data['path'][0]['user'][0]['comm']
+        path_to_cfg_data = file_paths.user.comm
         logger.debug('Path to commcfg.json: '+ path_to_cfg_data)
-        with open(absolute_path.replace('src/backend/comm', path_to_cfg_data)) as f:
+        with open(path_to_cfg_data) as f:
             connect_data = json.load(f)
     except Exception as e:
         logger.error('Backend: Failed to load communication config file.')
@@ -163,7 +151,7 @@ def save_commcfg(changed_data: dict()) -> None:
             connect_data['USE'] = 'UART'
             connect_data['UART'][0]['SERPORT'] = changed_data['SERPORT']
             connect_data['UART'][1]['BAUDRATE']= changed_data['BAUDRATE']
-        with open(absolute_path.replace('/src/backend/comm', path_to_cfg_data), 'w') as f:
+        with open(path_to_cfg_data, 'w') as f:
             logger.debug('New connect data: '+str(connect_data))
             json.dump(connect_data, f, indent=4)
         logger.info('Backend: Connection data are successfully stored in commcfg.json')
@@ -173,14 +161,10 @@ def save_commcfg(changed_data: dict()) -> None:
 
 def save_mapcfg(changed_data: dict()):
     logger.info('Backend: Writing new map and position data to the file')
-    absolute_path = os.path.dirname(__file__)
     try:
-        with open(absolute_path.replace('/src/backend/comm', '/src/data/datacfg.json')) as f:
-            path_to_data = json.load(f)
-            f.close()
-        path_to_cfg_data = path_to_data['path'][0]['user'][1]['mapcfg']
+        path_to_cfg_data = file_paths.user.mapcfg
         logger.debug('Path to mapcfg.json: '+ path_to_cfg_data)
-        with open(absolute_path.replace('src/backend/comm', path_to_cfg_data)) as f:
+        with open(path_to_cfg_data) as f:
             map_data = json.load(f)
     except Exception as e:
         logger.error('Backend: Failed to load map config file.')
@@ -196,7 +180,7 @@ def save_mapcfg(changed_data: dict()):
         map_data['POSITIONMODE'] = changed_data['POSITIONMODE']
         map_data['LON'] = changed_data['LON']
         map_data['LAT'] = changed_data['LAT']
-        with open(absolute_path.replace('/src/backend/comm', path_to_cfg_data), 'w') as f:
+        with open(path_to_cfg_data, 'w') as f:
             logger.debug('New map data: '+str(map_data))
             json.dump(map_data, f, indent=4)
         logger.info('Backend: Map data are successfully stored in mapcfg.json')
@@ -206,14 +190,10 @@ def save_mapcfg(changed_data: dict()):
     
 def save_appcfg(changed_data: dict()):
     logger.info('Backend: Writing new app data to the file')
-    absolute_path = os.path.dirname(__file__)
     try:
-        with open(absolute_path.replace('/src/backend/comm', '/src/data/datacfg.json')) as f:
-            path_to_data = json.load(f)
-            f.close()
-        path_to_cfg_data = path_to_data['path'][0]['user'][2]['appcfg']
+        path_to_cfg_data = file_paths.user.appcfg
         logger.debug('Path to appcfg.json: '+str(path_to_cfg_data))
-        with open(absolute_path.replace('src/backend/comm', path_to_cfg_data)) as f:
+        with open(path_to_cfg_data) as f:
             app_data = json.load(f)
     except Exception as e:
         logger.error('Backend: Failed to load app config file.')
@@ -226,7 +206,7 @@ def save_appcfg(changed_data: dict()):
         app_data['current_thd_charge'] = changed_data['current_thd_charge']
         app_data['voltage_to_soc'][0]['V'] = changed_data['voltage_to_soc'][0]['V']
         app_data['voltage_to_soc'][1]['V'] = changed_data['voltage_to_soc'][1]['V']
-        with open(absolute_path.replace('/src/backend/comm', path_to_cfg_data), 'w') as f:
+        with open(path_to_cfg_data, 'w') as f:
             logger.debug('New app data: '+str(app_data))
             json.dump(app_data, f, indent=4)
         logger.info('Backend: App data are successfully stored in appcfg.json')

--- a/CaSSAndRA/src/backend/comm/mqttcomm.py
+++ b/CaSSAndRA/src/backend/comm/mqttcomm.py
@@ -5,6 +5,7 @@ import time
 import json
 import paho.mqtt.client as mqtt
 import pandas as pd
+import random
 
 from src.backend.data import datatodf, roverdata, mapdata
 from . import cmdtorover, cmdlist, message
@@ -20,7 +21,7 @@ def cmd_to_rover(client, connect_data) -> None:
         
    
 def connect_mqtt(connect_data: dict()) -> mqtt:
-    client_id = connect_data['MQTT'][0]['CLIENT_ID'] 
+    client_id = connect_data['MQTT'][0]['CLIENT_ID'] + str(random.randint(1, 1000))
     username = connect_data['MQTT'][1]['USERNAME'] 
     password = connect_data['MQTT'][2]['PASSWORD']
     mqtt_server = connect_data['MQTT'][3]['MQTT_SERVER']

--- a/CaSSAndRA/src/backend/data/cfgdata.py
+++ b/CaSSAndRA/src/backend/data/cfgdata.py
@@ -9,7 +9,7 @@ import base64
 import pandas as pd
 from PIL import Image
 
-ABSOLUTE_PATH = os.path.dirname(__file__)
+file_paths = None
 
 #appcfg class
 @dataclass
@@ -72,19 +72,11 @@ class AppCfg:
     current_thd_charge: float = -0.03
     rover_picture: str = 'default/'
     rover_pictures: RoverIMG = RoverIMG()
+    file_path: str = ''
 
     def read_appcfg(self) -> None:
         try:
-            with open(ABSOLUTE_PATH.replace('/src/backend/data', '/src/data/datacfg.json')) as f: 
-                path_to_data = json.load(f)
-                f.close()
-        except Exception as e:
-            logger.error('Backend: Could not read appcfg.json. Missing datacfg.json')
-            logger.debug(str(e))
-            return
-        try:
-            path_to_appcfg = path_to_data['path'][0]['user'][2]['appcfg']
-            with open(ABSOLUTE_PATH.replace('/src/backend/data', path_to_appcfg)) as f: 
+            with open(file_paths.user.appcfg) as f: 
                 appcfg_from_file = json.load(f)
                 f.close()
         except Exception as e:
@@ -108,15 +100,6 @@ class AppCfg:
     
     def save_appcfg(self) -> int:
         try:
-            with open(ABSOLUTE_PATH.replace('/src/backend/data', '/src/data/datacfg.json')) as f: 
-                path_to_data = json.load(f)
-                f.close()
-        except Exception as e:
-            logger.error('Backend: Could not save appcfg.json. Missing datacfg.json')
-            logger.debug(str(e))
-            return -1
-        try:
-            path_to_appcfg = path_to_data['path'][0]['user'][2]['appcfg']
             new_data = dict()
             new_data['datamaxage'] = self.datamaxage
             new_data['time_to_offline'] = self.time_to_offline
@@ -124,7 +107,7 @@ class AppCfg:
             new_data['voltage_to_soc'] = soc_look_up_table
             new_data['current_thd_charge'] = self.current_thd_charge
             new_data['rover_picture'] = self.rover_picture
-            with open(ABSOLUTE_PATH.replace('/src/backend/data', path_to_appcfg), 'w') as f:
+            with open(file_paths.user.appcfg, 'w') as f:
                 logger.debug('New appcfg data: '+str(new_data))
                 json.dump(new_data, f, indent=4)
             logger.info('Backend: rovercfg data are successfully stored in appcfg.json')
@@ -144,21 +127,12 @@ class RoverCfg:
     mowspeed_setpoint: float = 0.3
     gotospeed_setpoint: float = 0.5
     positionmode: str = 'relative'
-    log: float = 0
+    lon: float = 0
     lat: float = 0
 
     def read_rovercfg(self) -> None:
         try:
-            with open(ABSOLUTE_PATH.replace('/src/backend/data', '/src/data/datacfg.json')) as f: 
-                path_to_data = json.load(f)
-                f.close()
-        except Exception as e:
-            logger.error('Backend: Could not read rovercfg.json. Missing datacfg.json')
-            logger.debug(str(e))
-            return
-        try:
-            path_to_rovercfg = path_to_data['path'][0]['user'][3]['rovercfg']
-            with open(ABSOLUTE_PATH.replace('/src/backend/data', path_to_rovercfg)) as f: 
+            with open(file_paths.user.rovercfg) as f: 
                 rovercfg_from_file = json.load(f)
                 f.close()
         except Exception as e:
@@ -179,22 +153,13 @@ class RoverCfg:
     
     def save_rovercfg(self) -> int:
         try:
-            with open(ABSOLUTE_PATH.replace('/src/backend/data', '/src/data/datacfg.json')) as f: 
-                path_to_data = json.load(f)
-                f.close()
-        except Exception as e:
-            logger.error('Backend: Could not save rovercfg.json. Missing datacfg.json')
-            logger.debug(str(e))
-            return -1
-        try:
-            path_to_rovercfg = path_to_data['path'][0]['user'][3]['rovercfg']
             new_data = dict()
             new_data['mowspeed_setpoint'] = self.mowspeed_setpoint
             new_data['gotospeed_setpoint'] = self.gotospeed_setpoint
             new_data['positionmode'] = self.positionmode
             new_data['lon'] = self.lon
             new_data['lat'] = self.lat
-            with open(ABSOLUTE_PATH.replace('/src/backend/data', path_to_rovercfg), 'w') as f:
+            with open(file_paths.user.rovercfg, 'w') as f:
                 logger.debug('New rovercfg data: '+str(new_data))
                 json.dump(new_data, f, indent=4)
             logger.info('Backend: rovercfg data are successfully stored in rovercfg.json')
@@ -218,16 +183,7 @@ class PathPlannerCfg:
 
     def read_pathplannercfg(self) -> None:
         try:
-            with open(ABSOLUTE_PATH.replace('/src/backend/data', '/src/data/datacfg.json')) as f: 
-                path_to_data = json.load(f)
-                f.close()
-        except Exception as e:
-            logger.error('Backend: Could not read pathplannercfg.json. Missing datacfg.json')
-            logger.debug(str(e))
-            return
-        try:
-            path_to_pathplannercfg = path_to_data['path'][0]['user'][4]['pathplannercfg']
-            with open(ABSOLUTE_PATH.replace('/src/backend/data', path_to_pathplannercfg)) as f: 
+            with open(file_paths.user.pathplannercfg) as f: 
                 pathplannercfg_from_file = json.load(f)
                 f.close()
         except Exception as e:
@@ -251,15 +207,6 @@ class PathPlannerCfg:
     
     def save_pathplannercfg(self) -> int:
         try:
-            with open(ABSOLUTE_PATH.replace('/src/backend/data', '/src/data/datacfg.json')) as f: 
-                path_to_data = json.load(f)
-                f.close()
-        except Exception as e:
-            logger.error('Backend: Could not save pathplannercfg.json. Missing datacfg.json')
-            logger.debug(str(e))
-            return -1
-        try:
-            path_to_pathplannercfg = path_to_data['path'][0]['user'][4]['pathplannercfg']
             new_data = dict()
             new_data['pattern'] = self.pattern
             new_data['width'] = self.width
@@ -269,7 +216,7 @@ class PathPlannerCfg:
             new_data['mowborder'] = self.mowborder
             new_data['mowexclusion'] = self.mowexclusion
             new_data['mowborderccw'] = self.mowborderccw
-            with open(ABSOLUTE_PATH.replace('/src/backend/data', path_to_pathplannercfg), 'w') as f:
+            with open(file_paths.user.pathplannercfg, 'w') as f:
                 logger.debug('New pathplannercfg data: '+str(new_data))
                 json.dump(new_data, f, indent=4)
             logger.info('Backend: pathplannercfg data are successfully stored in pathplannercfg.json')
@@ -290,17 +237,11 @@ class PathPlannerCfg:
         self.mowborderccw = parameters.iloc[0]['mowborderccw']
 
 rovercfg = RoverCfg()
-rovercfg.read_rovercfg()
 pathplannercfg = PathPlannerCfg()
-pathplannercfg.read_pathplannercfg()
 pathplannercfgstate = PathPlannerCfg()
-pathplannercfgstate.read_pathplannercfg()
 pathplannercfgtask = PathPlannerCfg()
-pathplannercfgtask.read_pathplannercfg()
 pathplannercfgtasktmp = PathPlannerCfg()
-pathplannercfgtasktmp.read_pathplannercfg()
 appcfg = AppCfg()
-appcfg.read_appcfg()
 
 
         

--- a/CaSSAndRA/src/backend/data/mapdata.py
+++ b/CaSSAndRA/src/backend/data/mapdata.py
@@ -35,6 +35,7 @@ class Perimeter:
     areatomow: float = 0
     distancetogo: float = 0
     map_crc: int = None
+    current_perimeter_file: str() = ''
 
     def set_gotopoint(self, clickdata: dict) -> None:
         goto = {'X':[clickdata['points'][0]['x']], 'Y':[clickdata['points'][0]['y']], 'type': ['way']}
@@ -180,9 +181,8 @@ class Perimeter:
         self.preview['type'] = 'preview route'
     
     def read_map_name(self) -> str():
-        absolute_path = os.path.dirname(__file__)
         try:
-            with open(absolute_path.replace('/src/backend/data', '/src/data/map/tmp.json')) as f: 
+            with open(self.current_perimeter_file) as f: 
                 tmp_data = json.load(f)
                 f.close()
                 return tmp_data['PERIMETERNAME']
@@ -192,10 +192,9 @@ class Perimeter:
             return ''
     
     def save_map_name(self) -> None:
-        absolute_path = os.path.dirname(__file__)
         tmp_data = {'PERIMETERNAME': self.name}
         try:
-            with open(absolute_path.replace('/src/backend/data', '/src/data/map/tmp.json'), 'w') as f:
+            with open(self.current_perimeter_file, 'w') as f:
                 json.dump(tmp_data, f, indent=4)
             logger.info('Backend: Perimeter name is successfully saved in tmp.json')
         except Exception as e:

--- a/CaSSAndRA/src/backend/data/utils.py
+++ b/CaSSAndRA/src/backend/data/utils.py
@@ -46,22 +46,28 @@ def init_data(data_path):
     file_paths.src = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
     file_paths.data = data_path
 
+    # user config files
     file_paths.user.comm = os.path.join(data_path, 'user', 'commcfg.json')
     file_paths.user.mapcfg = os.path.join(data_path, 'user', 'mapcfg.json')
     file_paths.user.appcfg = os.path.join(data_path, 'user', 'appcfg.json')
     file_paths.user.rovercfg = os.path.join(data_path, 'user', 'rovercfg.json')
     file_paths.user.pathplannercfg = os.path.join(data_path, 'user', 'pathplannercfg.json')
 
+    # measure and state files
     file_paths.measure.state = os.path.join(data_path, 'measure', 'state.pickle')
     file_paths.measure.stats = os.path.join(data_path, 'measure', 'stats.pickle')
     file_paths.measure.props = os.path.join(data_path, 'measure', 'props.pickle')
     file_paths.measure.calcedstate = os.path.join(data_path, 'measure', 'calcstate.pickle')
     file_paths.measure.calcedstats = os.path.join(data_path, 'measure', 'calcstats.pickle')
 
+    # map files
     file_paths.map.perimeter = os.path.join(data_path, 'map', 'perimeter.json')
     file_paths.map.tasks = os.path.join(data_path, 'map', 'tasks.json')
     file_paths.map.tasks_parameters = os.path.join(data_path, 'map', 'tasks_parameters.json')
     file_paths.map.tmp = os.path.join(data_path, 'map', 'tmp.json')
+
+    # log files
+    file_paths.log = os.path.join(data_path, 'log', 'cassandra.log')
 
     # initialize data folder from initial data, copying only what is missing
     create_missing_files(os.path.join(file_paths.src, 'data'), data_path)

--- a/CaSSAndRA/src/backend/data/utils.py
+++ b/CaSSAndRA/src/backend/data/utils.py
@@ -44,22 +44,24 @@ def init_data(data_path):
     #     os.makedirs(data_path)
 
     file_paths.src = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    file_paths.data = data_path
 
     file_paths.user.comm = os.path.join(data_path, 'user', 'commcfg.json')
-    file_paths.user.mapcfg = os.path.join(data_path, 'mapcfg', 'mapcfg.json')
-    file_paths.user.appcfg = os.path.join(data_path, 'appcfg', 'appcfg.json')
-    file_paths.user.rovercfg = os.path.join(data_path, 'rovercfg', 'rovercfg.json')
-    file_paths.user.pathplannercfg = os.path.join(data_path, 'pathplannercfg', 'pathplannercfg.json')
+    file_paths.user.mapcfg = os.path.join(data_path, 'user', 'mapcfg.json')
+    file_paths.user.appcfg = os.path.join(data_path, 'user', 'appcfg.json')
+    file_paths.user.rovercfg = os.path.join(data_path, 'user', 'rovercfg.json')
+    file_paths.user.pathplannercfg = os.path.join(data_path, 'user', 'pathplannercfg.json')
 
-    file_paths.measure.comm = os.path.join(data_path, 'measure', 'commcfg.pickle')
+    file_paths.measure.state = os.path.join(data_path, 'measure', 'state.pickle')
     file_paths.measure.stats = os.path.join(data_path, 'measure', 'stats.pickle')
     file_paths.measure.props = os.path.join(data_path, 'measure', 'props.pickle')
-    file_paths.measure.calcedstate = os.path.join(data_path, 'measure', 'calcedstate.pickle')
-    file_paths.measure.calcedstats = os.path.join(data_path, 'measure', 'calcedstats.pickle')
+    file_paths.measure.calcedstate = os.path.join(data_path, 'measure', 'calcstate.pickle')
+    file_paths.measure.calcedstats = os.path.join(data_path, 'measure', 'calcstats.pickle')
 
     file_paths.map.perimeter = os.path.join(data_path, 'map', 'perimeter.json')
     file_paths.map.tasks = os.path.join(data_path, 'map', 'tasks.json')
     file_paths.map.tasks_parameters = os.path.join(data_path, 'map', 'tasks_parameters.json')
+    file_paths.map.tmp = os.path.join(data_path, 'map', 'tmp.json')
 
     # initialize data folder from initial data, copying only what is missing
     create_missing_files(os.path.join(file_paths.src, 'data'), data_path)

--- a/CaSSAndRA/src/backend/data/utils.py
+++ b/CaSSAndRA/src/backend/data/utils.py
@@ -1,0 +1,67 @@
+import os
+import shutil
+from collections import namedtuple
+
+import logging
+logger = logging.getLogger(__name__)
+
+file_paths = namedtuple('FilePaths', ['src', 'user', 'measure', 'map'])
+file_paths.user = namedtuple('UserConfigPaths', ['comm', 'mapcfg', 'appcfg', 'rovercfg', 'pathplannercfg'])
+file_paths.measure = namedtuple('MeasureConfigPaths', ['state', 'stats', 'props', 'calcedstate', 'calcedstats'])
+file_paths.map = namedtuple("MapFilePaths", ['perimeter', 'tasks', 'tasks_parameters'])
+
+
+def create_missing_files(src_dir, dest_dir):
+    # Create the destination directory if it doesn't exist
+    if not os.path.exists(dest_dir):
+        logger.debug(f'Backend: Creating directory {dest_dir}')
+        os.makedirs(dest_dir)
+    else:
+        logger.debug(f'Backend: Using existing directory {dest_dir}')
+
+    # Iterate over each file and sub-directory in the source directory
+    for item in os.listdir(src_dir):
+        src_item_path = os.path.join(src_dir, item)
+        dest_item_path = os.path.join(dest_dir, item)
+
+        # If it's a file and does not exist in the destination directory, copy it
+        if os.path.isfile(src_item_path):
+            if not os.path.exists(dest_item_path):
+                logger.debug(f'Backend: Copying initial data file from {src_item_path} to {dest_item_path}')
+                shutil.copy(src_item_path, dest_item_path)
+            else:
+                logger.debug(f'Backend: Using existing file {dest_item_path}')
+                
+        # If it's a directory, recurse into it
+        elif os.path.isdir(src_item_path):
+            create_missing_files(src_item_path, dest_item_path)
+
+
+
+def init_data(data_path):
+
+    # if not os.path.exists(data_path):
+    #     os.makedirs(data_path)
+
+    file_paths.src = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+
+    file_paths.user.comm = os.path.join(data_path, 'user', 'commcfg.json')
+    file_paths.user.mapcfg = os.path.join(data_path, 'mapcfg', 'mapcfg.json')
+    file_paths.user.appcfg = os.path.join(data_path, 'appcfg', 'appcfg.json')
+    file_paths.user.rovercfg = os.path.join(data_path, 'rovercfg', 'rovercfg.json')
+    file_paths.user.pathplannercfg = os.path.join(data_path, 'pathplannercfg', 'pathplannercfg.json')
+
+    file_paths.measure.comm = os.path.join(data_path, 'measure', 'commcfg.pickle')
+    file_paths.measure.stats = os.path.join(data_path, 'measure', 'stats.pickle')
+    file_paths.measure.props = os.path.join(data_path, 'measure', 'props.pickle')
+    file_paths.measure.calcedstate = os.path.join(data_path, 'measure', 'calcedstate.pickle')
+    file_paths.measure.calcedstats = os.path.join(data_path, 'measure', 'calcedstats.pickle')
+
+    file_paths.map.perimeter = os.path.join(data_path, 'map', 'perimeter.json')
+    file_paths.map.tasks = os.path.join(data_path, 'map', 'tasks.json')
+    file_paths.map.tasks_parameters = os.path.join(data_path, 'map', 'tasks_parameters.json')
+
+    # initialize data folder from initial data, copying only what is missing
+    create_missing_files(os.path.join(file_paths.src, 'data'), data_path)
+
+    return file_paths

--- a/CaSSAndRA/src/layout.py
+++ b/CaSSAndRA/src/layout.py
@@ -1,0 +1,37 @@
+import dash
+from dash import html, dcc
+import dash_bootstrap_components as dbc
+
+from src.components import (
+    ids,
+    navbar,
+    offcanvas,
+    modalremotecontrol,
+    modalinfo,
+    modalerror,
+)
+
+
+def serve_layout() -> html.Div:
+    return html.Div(
+        [
+            dcc.Interval(id=ids.INTERVAL, interval=1 * 3000, n_intervals=0),
+            dcc.Interval(
+                id=ids.STATEMAPINTERVAL,
+                interval=1 * 1000,
+                n_intervals=0,
+                disabled=False,
+            ),
+            dcc.Interval(
+                id=ids.MAPPINGINTERVAL, interval=1 * 3000, n_intervals=0, disabled=True
+            ),
+            dcc.Location(id=ids.URLUPDATE, refresh=True),
+            navbar.navbar,
+            offcanvas.offcanvas,
+            modalremotecontrol.confirm,
+            modalinfo.info,
+            modalerror.mapuploadfailed,
+            dash.page_container
+            # footer
+        ]
+    )

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+	FROM python:3.10-slim
+    WORKDIR /usr/src/cassandra
+    COPY ./requirements.txt /usr/src/cassandra
+	RUN pip install --upgrade pip
+	RUN pip install -r requirements.txt
+	COPY ./CaSSAndRA .
+	CMD ["python3","app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,34 @@
 	FROM python:3.10-slim
-    WORKDIR /usr/src/cassandra
-    COPY ./requirements.txt /usr/src/cassandra
+	
+	# install sudo, so we can run app as cassandra user
+	RUN apt-get update && apt-get install -y sudo
+	
+	# add entrypoint script for handling host user/group ids
+	COPY ./docker_entrypoint.sh /docker_entrypoint.sh
+	RUN chmod 755 /docker_entrypoint.sh
+	
+	# setup a non-root user to execute the app
+	RUN useradd -m cassandra
+	WORKDIR /home/cassandra/app
+
+	# install app dependencies before copying app files
+	# this allows us to rebuild the image very quickly
+	# unless we are changing anything in requirements.txt
+    COPY ./requirements.txt .
 	RUN pip install --upgrade pip
 	RUN pip install -r requirements.txt
+	
+	# copy app files to our work directory (~/app)
 	COPY ./CaSSAndRA .
-	ENTRYPOINT ["python", "app.py"]
+	
+	# define the volume where our files will be stored
+	VOLUME ["/home/cassandra/.cassandra"]
+
+	# start docker run commands with the entrypoint script first
+	# remaining commands are executed immediately after and
+	# include any additional options passed on the command line
+	# 
+	# Note: if required, you can override the entrypoint by
+	#       passing the entrypoint option to the run command 
+	#       Example: --entrypoint /bin/bash
+	ENTRYPOINT ["/docker_entrypoint.sh", "python", "app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@
 	RUN pip install --upgrade pip
 	RUN pip install -r requirements.txt
 	COPY ./CaSSAndRA .
-	CMD ["python3","app.py"]
+	ENTRYPOINT ["python", "app.py"]

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Docker Entrypoint Script
+# 
+# This script is executed before the python app is run to:
+#   - Require HOST_UID and HOST_GID to be set
+#   - Update the cassandra user (created by dockerfile) to use 
+#     the same user and group ids as the host system
+#   - Drop root permissions, then execute all remaining commands
+#     passed to the docker run command as the cassandra user
+#
+# It is required to make sure we can:
+#   - Keep the volume files editable by the host system
+#       - Note: only a concern on linux, docker desktop for macos 
+#               handles the permission issues
+#   - Build the docker image without knowing the host user/group
+#     ahead of time
+
+set -e
+
+# Only continue if we have both the uid and gid specified
+if [[ -z "$HOST_UID" ]]; then
+    echo "ERROR: please set HOST_UID" >&2
+    exit 1
+fi
+if [[ -z "$HOST_GID" ]]; then
+    echo "ERROR: please set HOST_GID" >&2
+    exit 1
+fi
+
+# Modify the existing cassandra account to use the host group/user ids
+groupmod -o --gid "$HOST_GID" cassandra
+usermod --uid "$HOST_UID" cassandra
+
+# Drop privileges and execute next container command, or 'bash' if not specified.
+if [[ $# -gt 0 ]]; then
+    exec sudo -u cassandra -- "$@"
+else
+    exec sudo -u cassandra -- bash
+fi


### PR DESCRIPTION
The core change of this PR is the move the app data outside of the app folder. This is best practice for git projects and is essential for using docker. By moving data outside of the app folder, we can much more easily update the app, whether it is ran directly or with docker.

Changes:
* Adds dockerfile to the project, which could then automatically build on each commit to the project
* Makes the app default to using moving data outside the project folder in `~/.cassandra` by default
* Makes the entire app execution leverage input options, so that we can debug it, change where the data is stored, change the port, or ip address, or change the log level output without editing `app.py`
* Updates assets folder to better handle how app.py is executed
* Updates mqtt connection to avoid connection issues when debugging

Closes #42 and #57 