### PR TITLE
Resubscribe to MQTT Topics

### DIFF
--- a/CaSSAndRA/src/backend/backendserver.py
+++ b/CaSSAndRA/src/backend/backendserver.py
@@ -179,7 +179,7 @@ def start(file_paths) -> None:
     if connect_data['USE'] == 'MQTT':
         logger.info('Backend: Establishing MQTT connection to the MQTT-Server')
         mqtt_client = mqttcomm.connect_mqtt(connect_data)
-        mqttcomm.subscribe(mqtt_client, connect_data)
+        
         if mqtt_client.connection_flag:
             logger.info('Backend: Starting server thread')
             connection_thread = Thread(target=connect_mqtt, args=(mqtt_client, connect_data, restart, file_paths))


### PR DESCRIPTION
Previously, we would only subscribe when the backend server was first setup. If there is ever a disconnect by the mqtt client,  the client will auto reconnect. However, we need to resubscribe again before we'll receive messages again. This change does the following:

* Moves mqtt subscription setup to the `on_connect` callback
  * This is called the first time we connect, but also any time we reconnect
* Logs the disconnect reason in a new `on_disconnect` callback

Fixes issue #73 