### PR TITLE
Touchscreen zoom and mobile performance changes

### DIFF
--- a/CaSSAndRA/src/assets/script.js
+++ b/CaSSAndRA/src/assets/script.js
@@ -2,3 +2,60 @@ var linkTag=document.createElement('link');
 linkTag.rel = "manifest"
 linkTag.href = "/assets/manifest.json"
 document.getElementsByTagName('head')[0].appendChild(linkTag);
+
+// Zoom
+function waitForElm(selector) {
+    return new Promise(resolve => {
+        if (document.querySelector(selector)) {
+            return resolve(document.querySelector(selector));
+        }
+
+        const observer = new MutationObserver(mutations => {
+            if (document.querySelector(selector)) {
+                observer.disconnect();
+                resolve(document.querySelector(selector));
+            }
+        });
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+    });
+}
+
+waitForElm('#_pages_content').then((elm) => {
+    elm.addEventListener("touchstart", handlestart);
+    elm.addEventListener("touchmove", handlezoom);
+});
+
+pd = 0;
+function handlestart(e)
+{
+    if (e.touches.length == 2)
+    {
+        e.stopPropagation();
+        pd = Math.sqrt(Math.pow(e.touches[0].clientX - e.touches[1].clientX, 2) + Math.pow(e.touches[0].clientY - e.touches[1].clientY, 2));
+    }
+}
+
+function handlezoom(e)
+{
+    if (e.touches.length == 2)
+    {
+        e.stopPropagation();
+
+        x = (e.touches[0].clientX + e.touches[1].clientX) / 2.0;
+        y = (e.touches[0].clientY + e.touches[1].clientY) / 2.0;
+        d = Math.sqrt(Math.pow(e.touches[0].clientX - e.touches[1].clientX, 2) + Math.pow(e.touches[0].clientY - e.touches[1].clientY, 2));
+        dd = pd - d;
+        pd = d;
+
+        var newEv = new WheelEvent('wheel', {
+            clientX: x,
+            clientY: y, 
+            deltaY: dd,
+          });
+        document.getElementsByClassName("nsewdrag drag")[0].dispatchEvent(newEv);
+    }
+}

--- a/CaSSAndRA/src/assets/style.css
+++ b/CaSSAndRA/src/assets/style.css
@@ -1,4 +1,4 @@
-/*html margin-left*/
+/* html margin-left */
 .margin-5px{
   margin-left: 5px;
   margin-top: 5px;
@@ -119,11 +119,11 @@ body{
   overflow: hidden;
 }
 #react-entry-point > div:first-of-type > div:first-of-type{
-	overflow: hidden;
-	flex-grow: 1;
+    overflow: hidden;
+    flex-grow: 1;
 }
 #_pages_content{
-	height: 100%;
+    height: 100%;
 }
 
 /* Make sure we can still scroll when needed for pages like the Settings accordians */
@@ -204,14 +204,14 @@ html {
 
 .stateCardHeader
 {
-	padding-top: 0.25rem;
-	padding-bottom: 0.25rem;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
 }
 
 .stateCardBody
 {
-	padding-top: 0.6rem;
-	padding-bottom: 0.6rem;
+    padding-top: 0.6rem;
+    padding-bottom: 0.6rem;
 }
 
 /************************* End of Card Group Customizations ********************/
@@ -270,119 +270,117 @@ html {
 /* Log Table*/
 .log_table
 {
-	font-size: 0.8rem;
-	text-align: left;
+    font-size: 0.8rem;
+    text-align: left;
 }
 
 .log_table tbody td:nth-child(2){
-	overflow-wrap: anywhere;
+    overflow-wrap: anywhere;
 }
 
 /* Progress bar */
 .progress-bar-visible
 {
-	opacity: 0.9;
-	transition-duration: 0.5s;
-	transition-property: opacity;
+    opacity: 0.9;
+    transition-duration: 0.5s;
+    transition-property: opacity;
 }
 
 .progress-bar-hidden
 {
-	opacity: 0.0;
-	transition-duration: 1s;
-	transition-property: opacity;
+    opacity: 0.0;
+    transition-duration: 1s;
+    transition-property: opacity;
 }
 
 /* Progress bar container */
 .progress-bar-container-visible
 {
-	backdrop-filter: blur(2px);
-	transition-duration: 0.5s;
-	transition-property: backdrop-filter
+    backdrop-filter: blur(2px);
+    transition-duration: 0.5s;
+    transition-property: backdrop-filter
 }
 
 .progress-bar-container-hidden
 {
-	backdrop-filter: blur(0px);
-	transition-duration: 1s;
-	transition-property: backdrop-filter
+    backdrop-filter: blur(0px);
+    transition-duration: 1s;
+    transition-property: backdrop-filter
 }
 
 /* Modebar and plot styling */
 .modebar
 {
-	top: 0.3rem !important;
-	right: 0px !important;
+    top: 0.3rem !important;
+    right: 0px !important;
 }
 .modebar-group
 {
-	backdrop-filter: blur(2px);
-	top: 0 !important;
-	padding-left: 4px !important;
-	padding-right: 4px !important;
+    backdrop-filter: blur(2px);
+    top: 0 !important;
+    padding-left: 4px !important;
+    padding-right: 4px !important;
 }
 .modebar-btn svg
 {
-	top: 0px !important;
+    top: 0px !important;
 }
 .plotly [data-title]::before
 {
-	display: none !important;
+    display: none !important;
 }
 .plotly [data-title]::after
 {
-	display: none !important;
+    display: none !important;
 }
 .plotly-notifier
 {
-	display: none !important;
+    display: none !important;
 }
-.main-svg
+/* .main-svg
 {
-	-webkit-mask-size:100% 100%;
-	-webkit-mask-position:center;
-	-webkit-mask-repeat:no-repeat;
-	-webkit-mask-composite: source-in;
-	-webkit-mask: linear-gradient(to top,  transparent 0%, #ffff 0.3rem calc(100% - 0.3rem), transparent 100%);
+    -webkit-mask: linear-gradient(to top,  transparent 0%, #ffff 0.3rem calc(100% - 0.3rem), transparent 100%);
 }
 .svg-container:first-child:before
 {
-	display: block;
-	content: "";
-	position: absolute;
-	width: 100%;
-	height: 100%;
-	z-index: 2;
-	backdrop-filter: blur(2px);
-	pointer-events: none;
+    display: block;
+    content: "";
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: 2;
+    backdrop-filter: blur(2px);
+    pointer-events: none;
 
-	-webkit-mask-size:100% 100%;
-	-webkit-mask-position:center;
-	-webkit-mask-repeat:no-repeat;
-	-webkit-mask-composite: source-in;
-	-webkit-mask: linear-gradient(to top,  #ffff 0%, transparent 0.3rem calc(100% - 0.3rem), #ffff 100%);
-}
+    -webkit-mask: linear-gradient(to top,  #ffff 0%, transparent 0.3rem calc(100% - 0.3rem), #ffff 100%);
+} */
 .infolayer
 {
-	transform: translateY(2.25rem);
+    transform: translateY(2.25rem);
 }
 .annotation:last-child
 {
-	transform: translateY(-2.5rem);
+    transform: translateY(-2.5rem);
 }
 .navbar-toggler:focus
 {
-	box-shadow: none !important;
+    box-shadow: none !important;
 }
 .navbar-toggler:active
 {
-	text-decoration: none !important;
-	outline: 0 !important;
-	box-shadow: 0 0 0 0.1rem !important;
+    text-decoration: none !important;
+    outline: 0 !important;
+    box-shadow: 0 0 0 0.1rem !important;
 }
 
 /* Schedule */
 .schedule-day{}
 .schedule-day:nth-child(even){
-	background-color: rgba(0, 0, 0, 0.041);
+    background-color: rgba(0, 0, 0, 0.041);
+}
+
+/* Zoom */
+#_pages_content
+{
+    pointer-events: all;
 }

--- a/CaSSAndRA/src/components/state/map.py
+++ b/CaSSAndRA/src/components/state/map.py
@@ -17,11 +17,16 @@ statemap.update_layout(
                     scaleanchor='x',
                     gridcolor = '#eeeeee', 
                     zerolinecolor = 'lightgrey',
-                    showticklabels=False),
+                    showticklabels=False,
+                    showgrid=False,
+                    zeroline=False,
+                ),
                xaxis=dict(
                     gridcolor = '#eeeeee', 
                     zerolinecolor = 'lightgrey',
-                    showticklabels=False
+                    showticklabels=False,
+                    showgrid=False,
+                    zeroline=False,
                ),
                margin=dict(
                     b=0, #bottom margin 40px
@@ -165,7 +170,7 @@ def update(n_intervals: int,
                filtered = coords_filtered.loc[coords['type']==trace]
                traces.append(go.Scatter(x=filtered['X'], y=filtered['Y'], 
                                         name='perimeter', 
-                                        mode='lines+markers', 
+                                        mode='lines', 
                                         line=dict(color='#008080'), 
                                         marker=dict(size=3),
                                         hoverinfo='skip')) 

--- a/CaSSAndRA/src/components/state/map.py
+++ b/CaSSAndRA/src/components/state/map.py
@@ -170,9 +170,9 @@ def update(n_intervals: int,
                filtered = coords_filtered.loc[coords['type']==trace]
                traces.append(go.Scatter(x=filtered['X'], y=filtered['Y'], 
                                         name='perimeter', 
-                                        mode='lines', 
+                                        mode='lines+markers', 
                                         line=dict(color='#008080'), 
-                                        marker=dict(size=3),
+                                        marker=dict(size=1),
                                         hoverinfo='skip')) 
           #Plot dockpoints
           filtered = coords.loc[coords['type'] == 'dockpoints']

--- a/CaSSAndRA/src/components/tasks/map.py
+++ b/CaSSAndRA/src/components/tasks/map.py
@@ -139,9 +139,9 @@ def update(bpma_nclicks: int,
                filtered = coords_filtered.loc[coords['type']==trace]
                traces.append(go.Scatter(x=filtered['X'], y=filtered['Y'], 
                                         name='perimeter', 
-                                        mode='lines', 
+                                        mode='lines+markers', 
                                         line=dict(color='#008080'), 
-                                        marker=dict(size=3),
+                                        marker=dict(size=1),
                                         hoverinfo='skip')) 
 
     #plot preview if there

--- a/CaSSAndRA/src/components/tasks/map.py
+++ b/CaSSAndRA/src/components/tasks/map.py
@@ -16,11 +16,16 @@ tasksmap.update_layout(
                     scaleanchor='x',
                     gridcolor = '#eeeeee', 
                     zerolinecolor = 'lightgrey',
-                    showticklabels=False),
+                    showticklabels=False,
+                    showgrid=False,
+                    zeroline=False,
+                    ),
                xaxis=dict(
                     gridcolor = '#eeeeee', 
                     zerolinecolor = 'lightgrey',
-                    showticklabels=False
+                    showticklabels=False,
+                    showgrid=False,
+                    zeroline=False,
                ),
                margin=dict(
                     b=0, #bottom margin 40px
@@ -134,7 +139,7 @@ def update(bpma_nclicks: int,
                filtered = coords_filtered.loc[coords['type']==trace]
                traces.append(go.Scatter(x=filtered['X'], y=filtered['Y'], 
                                         name='perimeter', 
-                                        mode='lines+markers', 
+                                        mode='lines', 
                                         line=dict(color='#008080'), 
                                         marker=dict(size=3),
                                         hoverinfo='skip')) 


### PR DESCRIPTION
Grid lines seem to take a lot of CPU on mobile devices.

Adds simple touch zoom controls:
Takes touch events and fires a scroll wheel event if two finger are currently being registered, its a bit hacky but seems to work OK.
The plot wants to snap when the axis align with the middle of the traces, not sure how to get rid of this.

I guess this would close #50 